### PR TITLE
Add option - boolean: infer github links

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,9 @@ var through2 = require('through2'),
  */
 module.exports = function (options) {
   options = options || {};
+  var docOptions = {
+    github : !!(options.github || options.g)
+  };
   var files = [];
   options.format = options.format || 'html';
   var formatter = documentation.formats[options.format];
@@ -54,7 +57,7 @@ module.exports = function (options) {
   }, function (cb) {
     documentation(files.map(function(file) {
       return file.path;
-    }), {}, function(err, comments) {
+    }), docOptions, function(err, comments) {
       formatter(comments, {}, function (err, output) {
         if (options.format === 'json' || options.format === 'md') {
           this.push(new File({

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "gulp": "^3.8.11",
     "concat-stream": "^1.4.8",
     "prova": "^2.1.1",
+    "proxyquire": "^1.7.3",
     "tape": "^3.5.0"
   },
   "keywords": [

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@ var test = require('prova'),
   path = require('path'),
   concat = require('concat-stream'),
   gulp = require('gulp'),
+  proxyquire = require('proxyquire'),
   documentation = require('../');
 
 test('gulp-documentation', function(t) {
@@ -43,6 +44,24 @@ test('gulp-documentation html', function(t) {
       t.equal(d.length, 7);
       t.end();
     }));
+});
+
+test('gulp-documentation github links', function(t) {
+  var through2Stub = {
+      obj : function (indexes, callback) {
+        callback.call();
+      }
+    },
+    documentationStub = function(indexes, options) {
+      t.equal(options.github, true);
+      t.end();
+    },
+    documentationjs = proxyquire('../', {
+      'through2': through2Stub,
+      'documentation': documentationStub
+    });
+
+  documentationjs({ format: 'html', github: true });
 });
 
 test('gulp-documentation exit callback', function(t) {


### PR DESCRIPTION
Please review: Pass-through of boolean option `github` or `g` to documentationjs, so the output is linked to github.